### PR TITLE
Use python3 since on new macOS Monterey we do not have

### DIFF
--- a/commit-msg
+++ b/commit-msg
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python3
 
 # add-issue-id-hook version 1.1.0
 #


### PR DESCRIPTION
Doing this since on new macOS Monterey we do not have python in the environment by default